### PR TITLE
Minor bug fix in load_crystfel_geometry

### DIFF
--- a/cfelpyutils/crystfel_utils.py
+++ b/cfelpyutils/crystfel_utils.py
@@ -447,7 +447,7 @@ def load_crystfel_geometry(filename):
         'clen_for_centering': None,
         'adu_per_eV': None,
         'adu_per_photon': None,
-        'max_adu': float(x='inf'),
+        'max_adu': float('inf'),
         'mask': None,
         'mask_file': None,
         'satmap': None,


### PR DESCRIPTION
'max_adu': float(x='inf'), in default panel definition is causing python 3.7 to crash. Removed the x='inf' assignment. 