### PR TITLE
Require future package

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 numpy
+future

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ setup(
         Center For Free Electron Laser Science (CFEL) in Hamburg.
         """
     ),
-    install_requires=['numpy'],
+    install_requires=['numpy', 'future'],
     packages=['cfelpyutils'],
     include_package_data=True,
     platforms='any',


### PR DESCRIPTION
Commit 6aecae71db7b2c20d16cfad229f0059032dd13f2 added an import `from future.utils`. This adds a dependency so that installing `cfelpyutils` also installs `future`.